### PR TITLE
Release/0.1.1

### DIFF
--- a/.github/actions/nf-test/action.yml
+++ b/.github/actions/nf-test/action.yml
@@ -25,9 +25,9 @@ runs:
         version: "${{ env.NXF_VERSION }}"
 
     - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
       with:
-        python-version: "3.13"
+        python-version: "3.14"
 
     - name: Install nf-test
       uses: nf-core/setup-nf-test@v1
@@ -52,6 +52,8 @@ runs:
       with:
         auto-update-conda: true
         conda-solver: libmamba
+        channels: conda-forge
+        channel-priority: strict
         conda-remove-defaults: true
 
     - name: Run nf-test

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,12 +11,12 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - name: Set up Python 3.13
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - name: Set up Python 3.14
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install pre-commit
         run: pip install pre-commit
@@ -28,14 +28,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out pipeline code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install Nextflow
         uses: nf-core/setup-nextflow@v2
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           architecture: "x64"
 
       - name: read .nf-core.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload linting log file artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: linting-logs
           path: |

--- a/.github/workflows/linting_comment.yml
+++ b/.github/workflows/linting_comment.yml
@@ -21,7 +21,7 @@ jobs:
         run: echo "pr_number=$(cat linting-logs/PR_number.txt)" >> $GITHUB_OUTPUT
 
       - name: Post PR comment
-        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.pr_number.outputs.pr_number }}

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -18,7 +18,7 @@ concurrency:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  NFT_VER: "0.9.2"
+  NFT_VER: "0.9.3"
   NFT_WORKDIR: "~"
   NXF_ANSI_LOG: false
   NXF_SINGULARITY_CACHEDIR: ${{ github.workspace }}/.singularity
@@ -39,7 +39,7 @@ jobs:
           rm -rf ./* || true
           rm -rf ./.??* || true
           ls -la ./
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
@@ -83,7 +83,7 @@ jobs:
       TOTAL_SHARDS: ${{ needs.nf-test-changes.outputs.total_shards }}
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/template-version-comment.yml
+++ b/.github/workflows/template-version-comment.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out pipeline code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -1,6 +1,6 @@
 repository_type: pipeline
 
-nf_core_version: 3.3.2
+nf_core_version: 3.5.1
 
 lint:
   files_unchanged:
@@ -37,7 +37,7 @@ template:
   name: iridanextexample2
   description: An example pipeline for running on IRIDA-Next with nf-schema
   author: Steven Sutcliffe
-  version: 0.1.0
+  version: 0.1.1
   force: true
   outdir: .
   is_nfcore: false

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,4 +10,7 @@ testing/
 testing*
 *.pyc
 bin/
+.nf-test/
 ro-crate-metadata.json
+modules/nf-core/
+subworkflows/nf-core/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Updated`
 
-- Some minor updates to GitHub actions and `.nf-core.yml` to better match latest nf-core template. [PR #8](https://github.com/phac-nml/iridanextexample2/pull/8)
+- Some minor updates to GitHub actions and `.nf-core.yml` to better match latest nf-core template. [PR #8](https://github.com/phac-nml/iridanextexample2/pull/8) and [PR #11](https://github.com/phac-nml/iridanextexample2/pull/11)
 - Updated nf-core modules and subworkflows. [PR #8](https://github.com/phac-nml/iridanextexample2/pull/8)
 
 ## [0.1.0] - 2025-07-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.1] - 2026-01-26
 
 ### `Added`
 
@@ -32,3 +32,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a category of parameters for checking in IRIDA-Next (i.e. file-path, boolean, enum, and integer). [PR #7](https://github.com/phac-nml/iridanextexample2/pull/7)
 
 [0.1.0]: https://github.com/phac-nml/iridanextexample2/releases/tag/0.1.0
+[0.1.1]: https://github.com/phac-nml/iridanextexample2/releases/tag/0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adding GitHub CI tests against Nextflow `24.10.3`. [PR #8](https://github.com/phac-nml/iridanextexample2/pull/8)
   - Required downgrading minimum Nextflow version from `24.10.5` to `24.10.3`.
+- Added `task.ext.override_configured_container_registry` check so that the multiqc container from `community.wave.seqera.io` can be overridden for private container registries. [PR #11](https://github.com/phac-nml/iridanextexample2/pull/11)
 
 ### `Updated`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -15,7 +15,7 @@ process {
     publishDir = [
         path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
         mode: params.publish_dir_mode,
-        saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     ]
 
     withName: FASTQC {
@@ -27,7 +27,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/multiqc" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
         container = {
             workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -15,20 +15,26 @@ process {
     publishDir = [
         path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
         mode: params.publish_dir_mode,
-        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
     ]
 
     withName: FASTQC {
         ext.args = '--quiet'
     }
 
-    withName: 'MULTIQC' {
-        ext.args   = { params.multiqc_title ? "--title \"$params.multiqc_title\"" : '' }
+    withName: MULTIQC {
+        ext.args = { params.multiqc_title ? "--title \"${params.multiqc_title}\"" : '' }
         publishDir = [
             path: { "${params.outdir}/multiqc" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
         ]
+        container = {
+            workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+                ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/ef/eff0eafe78d5f3b65a6639265a16b89fdca88d06d18894f90fcdb50142004329/data'
+                : task.ext.override_configured_container_registry != false
+                    ? 'community.wave.seqera.io/library/multiqc:1.31--1efbafd542a23882'
+                    : 'library/multiqc:1.31--1efbafd542a23882'
+        }
     }
-
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -260,7 +260,7 @@ manifest {
     mainScript      = 'main.nf'
     defaultBranch   = 'main'
     nextflowVersion = '!>=24.10.3'
-    version         = '0.1.0'
+    version         = '0.1.1'
     doi             = ''
 }
 

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -7,7 +7,7 @@
                     "fastqc": "0.12.1"
                 },
                 "Workflow": {
-                    "phac-nml/iridanextexample2": "v0.1.0"
+                    "phac-nml/iridanextexample2": "v0.1.1"
                 }
             },
             [
@@ -115,9 +115,9 @@
             ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-07T14:41:41.180274463"
+        "timestamp": "2026-01-23T16:07:25.127584099"
     }
 }


### PR DESCRIPTION
- Updated some nf-core github actions to latest versions from `nf-core pipelines create` template
- Added `task.ext.override_configured_container_registry` check so that the multiqc container from `community.wave.seqera.io` can be overridden for private container registries.
- Set the proper version number for release 0.1.1

Work in support of **STRY0019983 - Downgrade minimum version of Nextflow for iridanextexample2 to version used by GSP**. The downgrade of Nextflow was completed previously in https://github.com/phac-nml/iridanextexample2/pull/9. This PR is to make a few more updates for a new release of the pipeline.

## STRY0019983 - Downgrade minimum version of Nextflow for iridanextexample2 to version used by GSP

- [x] Downgrade minimum nextflow version in nextflow.config for iridanextexample2 to 24.10.3 [Done in https://github.com/phac-nml/iridanextexample2/pull/9]
- [x] Make sure CI tests are testing against 24.10.3
- [x] Make new release of pipeline on GitHub

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
